### PR TITLE
fix header dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,14 @@ OBJECTS += $(CITRUSLEAF-OBJECTS:%=$(TARGET_OBJ)/common/citrusleaf/%)
 
 HOOKED-OBJECTS = $(CITRUSLEAF-OBJECTS:%=$(TARGET_OBJ)/common-hooked/citrusleaf/%)
 
+AEROSPIKE-HEADERS = $(patsubst $(SOURCE_INCL)/aerospike/%.h,%.h,$(wildcard $(SOURCE_INCL)/aerospike/*.h))
+CITRUSLEAF-HEADERS = $(patsubst $(SOURCE_INCL)/citrusleaf/%.h,%.h,$(wildcard $(SOURCE_INCL)/citrusleaf/*.h))
+
+HEADERS =
+HEADERS += $(AEROSPIKE-HEADERS:%=$(TARGET_INCL)/aerospike/%)
+HEADERS += $(CITRUSLEAF-HEADERS:%=$(TARGET_INCL)/citrusleaf/%)
+
+
 ###############################################################################
 ##  MAIN TARGETS                                                             ##
 ###############################################################################
@@ -133,7 +141,7 @@ HOOKED-OBJECTS = $(CITRUSLEAF-OBJECTS:%=$(TARGET_OBJ)/common-hooked/citrusleaf/%
 all: build prepare
 
 .PHONY: prepare
-prepare: $(TARGET_INCL)/citrusleaf/*.h $(TARGET_INCL)/aerospike/*.h
+prepare: $(HEADERS)
 
 .PHONY: build 
 build: libaerospike-common libaerospike-common-hooked


### PR DESCRIPTION
The wildcard dependency in prepare doesn't work (at least not with GNU make 3.82):

```
$ make
make -e -C /home/bene/projects/remerge/aerospike-client-c/modules/base prepare COMMON=/home/bene/projects/remerge/aerospike-client-c/modules/common
make[1]: Entering directory `/home/bene/projects/remerge/aerospike-client-c/modules/base'
make[1]: Nothing to be done for `prepare'.
make[1]: Leaving directory `/home/bene/projects/remerge/aerospike-client-c/modules/base'
make -e -C /home/bene/projects/remerge/aerospike-client-c/modules/common prepare
make[1]: Entering directory `/home/bene/projects/remerge/aerospike-client-c/modules/common'
make[1]: *** No rule to make target `target/Linux-x86_64/include/citrusleaf/*.h', needed by `prepare'.  Stop.
make[1]: Leaving directory `/home/bene/projects/remerge/aerospike-client-c/modules/common'
make: *** [COMMON-make-prepare] Error 2
```

This patch fixes the issue.
