### PR TITLE
New hashmap impl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ AEROSPIKE-OBJECTS += as_hashmap_iterator_hooks.o
 # val_hashmap
 AEROSPIKE-OBJECTS += primes.o
 AEROSPIKE-OBJECTS += as_val_hashmap.o
+AEROSPIKE-OBJECTS += as_val_hashmap_iterator.o
 
 AEROSPIKE-OBJECTS += as_vector.o
 AEROSPIKE-OBJECTS += as_password.o

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ AEROSPIKE-OBJECTS += as_hashmap_hooks.o
 AEROSPIKE-OBJECTS += as_hashmap_iterator.o
 AEROSPIKE-OBJECTS += as_hashmap_iterator_hooks.o
 
+# val_hashmap
+AEROSPIKE-OBJECTS += primes.o
+AEROSPIKE-OBJECTS += as_val_hashmap.o
+
 AEROSPIKE-OBJECTS += as_vector.o
 AEROSPIKE-OBJECTS += as_password.o
 AEROSPIKE-OBJECTS += crypt_blowfish.o

--- a/src/include/aerospike/as_map_iterator.h
+++ b/src/include/aerospike/as_map_iterator.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <aerospike/as_hashmap_iterator.h>
+#include <aerospike/as_val_hashmap_iterator.h>
 
 /******************************************************************************
  *	TYPES
@@ -28,6 +29,7 @@
  */
 typedef union as_map_iterator_u {
 	
-	as_hashmap_iterator 	hashmap;
+	as_hashmap_iterator 	_hashmap;
+	as_val_hashmap_iterator	_val_hashmap;
 
 } as_map_iterator;

--- a/src/include/aerospike/as_val_hashmap.h
+++ b/src/include/aerospike/as_val_hashmap.h
@@ -35,7 +35,8 @@ typedef struct _as_val_hashmap {
 extern as_val_hashmap *as_val_hashmap_init(as_val_hashmap *map, size_t inicap);
 extern as_val_hashmap *as_val_hashmap_new(float min_lf, float max_lf,
 					  size_t inicap);
-extern bool as_val_hashmap_destroy(as_val_hashmap *map);
+extern bool as_val_hashmap_release(as_val_hashmap *map);
+extern void as_val_hashmap_destroy(as_val_hashmap *map);
 
 extern uint32_t as_val_hashmap_hashcode(const as_val_hashmap *map);
 

--- a/src/include/aerospike/as_val_hashmap.h
+++ b/src/include/aerospike/as_val_hashmap.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2014		Aaloan Miftah <aaloanm@smrtb.com>
+ *
+ * Licensed under GPLv2.
+ *
+ * Hash map implementation for as_val key/value pairs.
+ */
+#ifndef _AEROSPIKE_AS_VAL_HASHMAP_H_
+#define _AEROSPIKE_AS_VAL_HASHMAP_H_ 1
+
+#include <aerospike/as_map.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct _as_val_hashmap {
+	/* private: internal use only */
+	as_map _;
+
+	float min_lf;		/* load factor before shrinking */
+	float max_lf;		/* load factor before expanding */
+
+	size_t lo_wm;		/* low watermark */
+	size_t hi_wm;		/* high watermark */
+	size_t nr_fr;		/* number of entries free */
+
+	size_t size;		/* number of entries full */
+	size_t cap;		/* total capacity */
+
+	as_val **key_tbl;	/* key table */
+	as_val **val_tbl;	/* value table */
+	char	*st;		/* table state */
+} as_val_hashmap;
+
+extern as_val_hashmap *as_val_hashmap_init(as_val_hashmap *map, size_t inicap);
+extern as_val_hashmap *as_val_hashmap_new(float min_lf, float max_lf,
+					  size_t inicap);
+extern bool as_val_hashmap_destroy(as_val_hashmap *map);
+
+extern uint32_t as_val_hashmap_hashcode(const as_val_hashmap *map);
+
+/**
+ * Retrieve the number of entries in a map.
+ *
+ * @param map	target map
+ * @return	number of entries in @map
+ * @relatealso	as_val_hashmap
+ */
+static inline uint32_t as_val_hashmap_size(const as_val_hashmap *map)
+{
+	return map->size;
+}
+
+extern void as_val_hashmap_clear(as_val_hashmap *map);
+
+extern as_val *as_val_hashmap_get(const as_val_hashmap *map, const as_val *k);
+extern as_val *as_val_hashmap_set(as_val_hashmap *map, as_val *k, as_val *v);
+extern as_val *as_val_hashmap_remove(as_val_hashmap *map, const as_val *k);
+
+extern bool as_val_hashmap_foreach(const as_val_hashmap *map,
+				   as_map_foreach_callback cb, void *udata);
+
+/**
+ * as_val_hashmap_foreach_entry() - iterate through all full entries in a map
+ * @pos:	cursor
+ * @count:	entry counter
+ * @map:	&as_val_hashmap
+ */
+#define as_val_hashmap_foreach_entry(pos, count, map)			\
+	for (pos = 0, count = 0; count != (map)->size; pos++,		\
+		count += ((map)->st[pos-1] == ST_FULL ? 1 : 0))		\
+		if ((map)->st[pos] == ST_FULL)
+
+#endif /* _AEROSPIKE_AS_VAL_HASHMAP_H_ */

--- a/src/include/aerospike/as_val_hashmap.h
+++ b/src/include/aerospike/as_val_hashmap.h
@@ -13,6 +13,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef AS_VAL_HASHMAP_PRIVATE
+enum {
+	ST_FREE = 0,
+	ST_FULL,
+	ST_REMOVED
+};
+#endif
+
 typedef struct _as_val_hashmap {
 	/* private: internal use only */
 	as_map _;

--- a/src/include/aerospike/as_val_hashmap.h
+++ b/src/include/aerospike/as_val_hashmap.h
@@ -51,7 +51,7 @@ static inline uint32_t as_val_hashmap_size(const as_val_hashmap *map)
 	return map->size;
 }
 
-extern void as_val_hashmap_clear(as_val_hashmap *map);
+extern int as_val_hashmap_clear(as_val_hashmap *map);
 
 extern as_val *as_val_hashmap_get(const as_val_hashmap *map, const as_val *k);
 extern as_val *as_val_hashmap_set(as_val_hashmap *map, as_val *k, as_val *v);

--- a/src/include/aerospike/as_val_hashmap_iterator.h
+++ b/src/include/aerospike/as_val_hashmap_iterator.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2014		Aaloan Miftah <aaloanm@smrtb.com>
+ *
+ * Licensed under GPLv2.
+ *
+ * val_hashmap iterator
+ */
+#ifndef _AEROSPIKE_AS_VAL_HASHMAP_ITERATOR_H_
+#define _AEROSPIKE_AS_VAL_HASHMAP_ITERATOR_H_ 1
+
+#include <aerospike/as_val_hashmap.h>
+#include <aerospike/as_iterator.h>
+#include <aerospike/as_pair.h>
+
+#include <stdbool.h>
+
+typedef struct _as_val_hashmap_iterator {
+	as_iterator _;
+
+	as_val_hashmap *map;	/* map we're iterating over */
+	bool next;		/* next entry indicator */
+	size_t pos;		/* cursor */
+	size_t count;		/* nth entry */
+	as_pair pair;		/* current pair */
+} as_val_hashmap_iterator;
+
+extern as_val_hashmap_iterator *as_val_hashmap_iterator_init(
+	as_val_hashmap_iterator *itr, as_val_hashmap *map);
+extern as_val_hashmap_iterator *as_val_hashmap_iterator_new(
+	as_val_hashmap *map);
+extern bool as_val_hashmap_iterator_release(as_val_hashmap_iterator *itr);
+extern void as_val_hashmap_iterator_destroy(as_val_hashmap_iterator *itr);
+
+extern bool as_val_hashmap_iterator_has_next(
+	const as_val_hashmap_iterator *itr);
+extern const as_val *as_val_hashmap_iterator_next(as_val_hashmap_iterator *itr);
+
+#endif /* _AEROSPIKE_AS_VAL_HASHMAP_ITERATOR_H_ */

--- a/src/main/aerospike/as_val_hashmap.c
+++ b/src/main/aerospike/as_val_hashmap.c
@@ -38,7 +38,8 @@ static const as_map_hooks map_hooks = {
 	__hook(set,		as_val_hashmap_set),
 	__hook(get,		as_val_hashmap_get),
 	__hook(remove,		as_val_hashmap_remove),
-	__hook(clear,		as_val_hashmap_clear)
+	__hook(clear,		as_val_hashmap_clear),
+	__hook(foreach,		as_val_hashmap_foreach)
 };
 
 /**

--- a/src/main/aerospike/as_val_hashmap.c
+++ b/src/main/aerospike/as_val_hashmap.c
@@ -19,6 +19,7 @@
 #include <aerospike/as_string.h>
 #include <aerospike/as_pair.h>
 #include <aerospike/as_val_hashmap.h>
+#include <aerospike/as_val_hashmap_iterator.h>
 
 #include "primes.h"
 
@@ -35,7 +36,9 @@ static const as_map_hooks map_hooks = {
 	__hook(get,		as_val_hashmap_get),
 	__hook(remove,		as_val_hashmap_remove),
 	__hook(clear,		as_val_hashmap_clear),
-	__hook(foreach,		as_val_hashmap_foreach)
+	__hook(foreach,		as_val_hashmap_foreach),
+	__hook(iterator_new,	as_val_hashmap_iterator_new),
+	__hook(iterator_init,	as_val_hashmap_iterator_init)
 };
 
 /**

--- a/src/main/aerospike/as_val_hashmap.c
+++ b/src/main/aerospike/as_val_hashmap.c
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2014 (C)		Aaloan Miftah <aaloanm@smrtb.com>
+ * Copyright 1999 (C)		CERN - European Organization for Nuclear Research
+ *
+ * Licensed under GPLv2.
+ *
+ * Hash map implementation for as_val key/value pairs.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <citrusleaf/alloc.h>
+#include <aerospike/as_boolean.h>
+#include <aerospike/as_integer.h>
+#include <aerospike/as_string.h>
+#include <aerospike/as_pair.h>
+#include <aerospike/as_val_hashmap.h>
+
+#include "primes.h"
+
+#define DEFAULT_MAX_LOAD_FACTOR		0.75f
+#define DEFAULT_MIN_LOAD_FACTOR		0.50f
+
+/* table entry states */
+enum {
+	ST_FREE = 0,
+	ST_FULL,
+	ST_REMOVED
+};
+
+/* as_map fn hook table */
+#define __hook(t, n) .t = (typeof(map_hooks.t)) n
+static const as_map_hooks map_hooks = {
+	__hook(destroy,		as_val_hashmap_destroy),
+	__hook(hashcode,	as_val_hashmap_hashcode),
+	__hook(size,		as_val_hashmap_size),
+	__hook(set,		as_val_hashmap_set),
+	__hook(get,		as_val_hashmap_get),
+	__hook(remove,		as_val_hashmap_remove),
+	__hook(clear,		as_val_hashmap_clear)
+};
+
+/**
+ * choose_hiwm() - calculate high watermark threshold for a map
+ * @map:	const &as_val_hashmap
+ */
+static inline size_t choose_hiwm(const as_val_hashmap *map)
+{
+	size_t cap = map->cap;
+	size_t x = cap - 2;
+	size_t y = (size_t) (cap * map->max_lf);
+	return x < y ? x : y;
+}
+
+/**
+ * choose_lowm() - calculate low watermark threshold for a map
+ */
+static inline size_t choose_lowm(const as_val_hashmap *map)
+{
+	return (size_t) (map->cap * map->min_lf);
+}
+
+/**
+ * choose_grow_cap() - calculate new capacity for expansion
+ */
+static inline size_t choose_grow_cap(const as_val_hashmap *map)
+{
+	size_t sz = map->size + 1;
+	size_t x = sz + 1;
+	size_t y = (size_t) ((4 * sz) / (3 * map->min_lf + map->max_lf));
+	return next_prime(x > y ? x : y);
+}
+
+/**
+ * choose_shrink_cap() - calculate new capacity for shrinking
+ */
+static inline size_t choose_shrink_cap(const as_val_hashmap *map)
+{
+	size_t sz = map->size;
+	size_t x = sz + 1;
+	size_t y = (size_t) ((4 * sz) / (map->min_lf + 3 * map->max_lf));
+	return next_prime(x > y ? x : y);
+}
+
+/**
+ * eq_val() - compare two values for equality
+ */
+static bool eq_val(const as_val *x, const as_val *y)
+{
+	if (!x && !y)
+		return true;
+	if (!x || !y)
+		return false;
+	if (as_val_type(x) != as_val_type(y))
+		return false;
+	switch (as_val_type(x)) {
+	case AS_NIL:
+		return true;
+	case AS_BOOLEAN:
+		return as_boolean_get((const as_boolean *) x) ==
+			as_boolean_get((const as_boolean *) y);
+	case AS_INTEGER:
+		return as_integer_get((const as_integer *) x) ==
+			as_integer_get((const as_integer *) y);
+	case AS_STRING:
+		return strcmp(as_string_get((const as_string *) x),
+			      as_string_get((const as_string *) y)) == 0;
+	case AS_PAIR:
+		return eq_val(as_pair_1((as_pair *) x),
+			      as_pair_1((as_pair *) y)) &&
+		       eq_val(as_pair_2((as_pair *) x),
+			      as_pair_2((as_pair *) y));
+	case AS_LIST:
+	case AS_MAP:
+	case AS_REC:
+	case AS_BYTES:
+		/* TODO */
+	default:
+		return false;
+	}
+}
+
+/**
+ * indexof() - determine index of key in a map
+ * @map:	haystack
+ * @k:		needle
+ *
+ * If @k is found in @map, a positive value denoting index of @k in @map,
+ * otherwise -1 is returned.
+ */
+static ssize_t indexof(const as_val_hashmap *map, const as_val *k)
+{
+	char s;
+	const char *st = map->st;
+	size_t cap = map->cap;
+	uint32_t hash = as_val_hashcode(k);
+	ssize_t idx = hash % cap;
+	uint32_t dec = hash % (cap - 2);
+	if (dec == 0)
+		dec = 1;
+	while ((s = st[idx]) != ST_FREE &&
+		(s == ST_REMOVED || !eq_val(map->key_tbl[idx], k))) {
+		idx -= dec;
+		if (idx < 0)
+			idx += cap;
+	}
+	return s == ST_FREE ? -1 : idx;
+}
+
+/**
+ * indexof_insert() - determine index to insert key at in map
+ * @map:	haystack
+ * @k:		needle
+ *
+ * If @k exists in @map, '-index - 1' is returned, otherwise a positive
+ * value denoting the suggested insertion index.
+ */
+static ssize_t indexof_insert(const as_val_hashmap *map, const as_val *k)
+{
+	char s;
+	const char *st = map->st;
+	size_t cap = map->cap;
+	uint32_t hash = as_val_hashcode(k);
+	ssize_t idx = hash % cap;
+	uint32_t dec = hash % (cap - 2);
+	if (dec == 0)
+		dec = 1;
+	while ((s = st[idx]) == ST_FULL && !eq_val(map->key_tbl[idx], k)) {
+		idx -= dec;
+		if (idx < 0)
+			idx += cap;
+	}
+	if (s == ST_REMOVED) {
+		size_t j = idx;
+		while ((s = st[idx]) != ST_FREE &&
+			(s == ST_REMOVED || !eq_val(map->key_tbl[idx], k))) {
+			idx -= dec;
+			if (idx < 0)
+				idx += cap;
+		}
+		if (s == ST_FREE)
+			idx = j;
+	}
+	return s == ST_FULL ? (-idx - 1) : idx;
+}
+
+/**
+ * resize_hash_map() - resize hash map
+ * @map:	target map
+ * @cap:	new capacity
+ */
+static void resize_hash_map(as_val_hashmap *map, size_t cap)
+{
+	size_t i, j;
+	as_val_hashmap old_map = *map;
+
+	map->cap = cap;
+	map->nr_fr = cap - map->size;
+	map->lo_wm = choose_lowm(map);
+	map->hi_wm = choose_hiwm(map);
+	map->st = cf_malloc(cap);
+	map->key_tbl = cf_malloc(sizeof(as_val *) * cap);
+	map->val_tbl = cf_malloc(sizeof(as_val *) * cap);
+
+	memset(map->st, ST_FREE, cap);
+
+	as_val_hashmap_foreach_entry(i, j, &old_map) {
+		as_val *k = old_map.key_tbl[i];
+		as_val *v = old_map.val_tbl[i];
+		ssize_t idx = indexof_insert(map, k);
+		map->key_tbl[idx] = k;
+		map->val_tbl[idx] = v;
+		map->st[idx] = ST_FULL;
+	}
+	cf_free(old_map.st);
+	cf_free(old_map.key_tbl);
+	cf_free(old_map.val_tbl);
+}
+
+/**
+ * Initialize hash map structure.
+ *
+ * @param map	target map
+ * @param cap	initial capacity
+ * @return	on success @map is returned, otherwise NULL.
+ */
+as_val_hashmap *as_val_hashmap_init(as_val_hashmap *map, size_t cap)
+{
+	if (!map)
+		return NULL;
+
+	/* calculate next prime capacity from initial capacity */
+	cap = next_prime(cap);
+
+	/* set default values if not present or invalid */
+	if (map->max_lf <= 0.0f || map->max_lf > 1.0f)
+		map->max_lf = DEFAULT_MAX_LOAD_FACTOR;
+	if (map->min_lf < 0.0f || map->min_lf >= 1.0f)
+		map->min_lf = DEFAULT_MIN_LOAD_FACTOR;
+
+	/* initialize val_hashmap */
+	map->size = 0;
+	map->cap = cap;
+	map->nr_fr = cap;
+	map->lo_wm = 0;
+	map->hi_wm = choose_hiwm(map);
+
+	map->key_tbl = cf_malloc(sizeof(as_val *) * cap);
+	if (!map->key_tbl)
+		goto out_mem;
+	map->val_tbl = cf_malloc(sizeof(as_val *) * cap);
+	if (!map->val_tbl)
+		goto out_key_tbl;
+	map->st = cf_malloc(cap);
+	if (!map->st)
+		goto out_val_tbl;
+
+	memset(map->st, ST_FREE, cap);
+
+	/* initialize parent map structure */
+	as_map_cons((as_map *) map, false, NULL, &map_hooks);
+	return map;
+out_val_tbl:
+	cf_free(map->val_tbl);
+out_key_tbl:
+	cf_free(map->key_tbl);
+out_mem:
+	return NULL;
+}
+
+/**
+ * Allocate and initialize hash map
+ *
+ * @param min_lf	minimum load factor before shrinking map [0..1)
+ * @param max_lf	maximum load factor before expanding map (0..1]
+ * @param inicap	initial capacity
+ * @return		pointer to new hash map, or NULL
+ */
+as_val_hashmap *as_val_hashmap_new(float min_lf, float max_lf, size_t inicap)
+{
+	as_val_hashmap *map = cf_malloc(sizeof(as_val_hashmap));
+	if (!map)
+		return NULL;
+	map->min_lf = min_lf;
+	map->max_lf = max_lf;
+	return as_val_hashmap_init(map, inicap);
+}
+
+/**
+ * Release hash map
+ *
+ * @param map	target map
+ */
+bool as_val_hashmap_destroy(as_val_hashmap *map)
+{
+	cf_free(map->st);
+	cf_free(map->key_tbl);
+	cf_free(map->val_tbl);
+	return true;
+}
+
+/**
+ * Calculate hash code of map
+ *
+ * @param map	target map
+ * @return	hash code of map
+ */
+uint32_t as_val_hashmap_hashcode(const as_val_hashmap *map)
+{
+	size_t i, j;
+	uint32_t hash = 0;
+	as_val_hashmap_foreach_entry(i, j, map) {
+		hash = as_val_hashcode(map->key_tbl[i]) ^
+			as_val_hashcode(map->val_tbl[i]);
+	}
+	return hash;
+}
+
+/**
+ * Retrive mapping for key
+ *
+ * @param map	target map
+ * @param k	key to search for
+ * @return	value mapped to @k, or NULL if @k has no mapping
+ */
+as_val *as_val_hashmap_get(const as_val_hashmap *map, const as_val *k)
+{
+	ssize_t idx = indexof(map, k);
+	if (idx < 0)
+		return NULL;
+	return map->val_tbl[idx];
+}
+
+/**
+ * Map value to key
+ *
+ * @param map	target map
+ * @param k	key
+ * @param v	value
+ * @return	previous value mapped to @k, or NULL if @k had no previous mapping
+ */
+as_val *as_val_hashmap_set(as_val_hashmap *map, as_val *k, as_val *v)
+{
+	ssize_t idx = indexof_insert(map, k);
+	if (idx < 0) {
+		as_val *old_v;
+
+		idx = -idx - 1;
+		old_v = map->val_tbl[idx];
+		map->val_tbl[idx] = v;
+		return old_v;
+	}
+
+	if (map->size > map->hi_wm) {
+		size_t new_cap = choose_grow_cap(map);
+		resize_hash_map(map, new_cap);
+		return as_val_hashmap_set(map, k, v);
+	}
+
+	map->key_tbl[idx] = k;
+	map->val_tbl[idx] = v;
+	if (map->st[idx] == ST_FREE)
+		map->nr_fr--;
+	map->st[idx] = ST_FULL;
+	map->size++;
+	if (map->nr_fr < 1) {
+		size_t new_cap = choose_grow_cap(map);
+		resize_hash_map(map, new_cap);
+	}
+	return NULL;
+}
+
+/**
+ * Remove mapping for key
+ *
+ * @param map	target map
+ * @param k	key
+ * @return	value that was mapped to @k, or NULL if @k had no mapping
+ */
+as_val *as_val_hashmap_remove(as_val_hashmap *map, const as_val *k)
+{
+	as_val *old_v;
+	ssize_t idx = indexof(map, k);
+	if (idx < 0)
+		return NULL;
+	old_v = map->val_tbl[idx];
+	map->st[idx] = ST_REMOVED;
+	map->size--;
+	if (map->size < map->lo_wm) {
+		size_t new_cap = choose_shrink_cap(map);
+		resize_hash_map(map, new_cap);
+	}
+	return old_v;
+}
+
+/**
+ * Iterate through all mappings in a map
+ *
+ * @param map	target map
+ * @param cb	callback function
+ * @param udata	user data
+ * @return true on success, false otherwise
+ */
+bool as_val_hashmap_foreach(const as_val_hashmap *map,
+			    as_map_foreach_callback cb, void *udata)
+{
+	size_t i, j;
+	as_val_hashmap_foreach_entry(i, j, map) {
+		const as_val *k = map->key_tbl[i];
+		const as_val *v = map->val_tbl[i];
+		if (!cb(k, v, udata))
+			break;
+	}
+	return true;
+}

--- a/src/main/aerospike/as_val_hashmap.c
+++ b/src/main/aerospike/as_val_hashmap.c
@@ -10,6 +10,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* we need state constants (ST_FREE, etc.) */
+#define AS_VAL_HASHMAP_PRIVATE 1
+
 #include <citrusleaf/alloc.h>
 #include <aerospike/as_boolean.h>
 #include <aerospike/as_integer.h>
@@ -21,13 +24,6 @@
 
 #define DEFAULT_MAX_LOAD_FACTOR		0.75f
 #define DEFAULT_MIN_LOAD_FACTOR		0.50f
-
-/* table entry states */
-enum {
-	ST_FREE = 0,
-	ST_FULL,
-	ST_REMOVED
-};
 
 /* as_map fn hook table */
 #define __hook(t, n) .t = (typeof(map_hooks.t)) n

--- a/src/main/aerospike/as_val_hashmap.c
+++ b/src/main/aerospike/as_val_hashmap.c
@@ -231,7 +231,10 @@ as_val_hashmap *__as_val_hashmap_init(as_val_hashmap *map, size_t cap)
 		return NULL;
 
 	/* calculate next prime capacity from initial capacity */
-	cap = next_prime(cap);
+	if (cap < 3)
+		cap = 3;
+	else
+		cap = next_prime(cap);
 
 	/* set default values if not present or invalid */
 	if (map->max_lf <= 0.0f || map->max_lf > 1.0f)

--- a/src/main/aerospike/as_val_hashmap.c
+++ b/src/main/aerospike/as_val_hashmap.c
@@ -26,15 +26,27 @@
 #define DEFAULT_MAX_LOAD_FACTOR		0.75f
 #define DEFAULT_MIN_LOAD_FACTOR		0.50f
 
+static int __as_map_set(as_val_hashmap *m, const as_val *k, const as_val *v)
+{
+	as_val_hashmap_set(m, (as_val *) k, (as_val *) v);
+	return 0;
+}
+
+static int __as_map_remove(as_val_hashmap *m, const as_val *k)
+{
+	as_val_hashmap_remove(m, (as_val *) k);
+	return 0;
+}
+
 /* as_map fn hook table */
 #define __hook(t, n) .t = (typeof(map_hooks.t)) n
 static const as_map_hooks map_hooks = {
 	__hook(destroy,		as_val_hashmap_release),
 	__hook(hashcode,	as_val_hashmap_hashcode),
 	__hook(size,		as_val_hashmap_size),
-	__hook(set,		as_val_hashmap_set),
+	__hook(set,		__as_map_set),
 	__hook(get,		as_val_hashmap_get),
-	__hook(remove,		as_val_hashmap_remove),
+	__hook(remove,		__as_map_remove),
 	__hook(clear,		as_val_hashmap_clear),
 	__hook(foreach,		as_val_hashmap_foreach),
 	__hook(iterator_new,	as_val_hashmap_iterator_new),

--- a/src/main/aerospike/as_val_hashmap.c
+++ b/src/main/aerospike/as_val_hashmap.c
@@ -318,6 +318,25 @@ uint32_t as_val_hashmap_hashcode(const as_val_hashmap *map)
 }
 
 /**
+ * Remove all mappings from map
+ *
+ * @param map	target map
+ * @return	always returns 0
+ */
+int as_val_hashmap_clear(as_val_hashmap *map)
+{
+	size_t new_cap;
+
+	map->size = 0;
+	map->nr_fr = map->cap;
+	memset(map->st, ST_FREE, map->cap);
+
+	new_cap = choose_shrink_cap(map);
+	resize_hash_map(map, new_cap);
+	return 0;
+}
+
+/**
  * Retrive mapping for key
  *
  * @param map	target map

--- a/src/main/aerospike/as_val_hashmap.c
+++ b/src/main/aerospike/as_val_hashmap.c
@@ -20,6 +20,7 @@
 #include <aerospike/as_pair.h>
 #include <aerospike/as_val_hashmap.h>
 #include <aerospike/as_val_hashmap_iterator.h>
+#include <aerospike/as_map_iterator.h>
 
 #include "primes.h"
 
@@ -38,6 +39,12 @@ static int __as_map_remove(as_val_hashmap *m, const as_val *k)
 	return 0;
 }
 
+static as_map_iterator *__as_map_iter_init(as_val_hashmap *map,
+					   as_val_hashmap_iterator *itr)
+{
+	return (as_map_iterator *) as_val_hashmap_iterator_init(itr, map);
+}
+
 /* as_map fn hook table */
 #define __hook(t, n) .t = (typeof(map_hooks.t)) n
 static const as_map_hooks map_hooks = {
@@ -50,7 +57,7 @@ static const as_map_hooks map_hooks = {
 	__hook(clear,		as_val_hashmap_clear),
 	__hook(foreach,		as_val_hashmap_foreach),
 	__hook(iterator_new,	as_val_hashmap_iterator_new),
-	__hook(iterator_init,	as_val_hashmap_iterator_init)
+	__hook(iterator_init,	__as_map_iter_init)
 };
 
 /**

--- a/src/main/aerospike/as_val_hashmap_iterator.c
+++ b/src/main/aerospike/as_val_hashmap_iterator.c
@@ -1,0 +1,124 @@
+#include <stdint.h>
+
+#define AS_VAL_HASHMAP_PRIVATE 1
+
+#include <citrusleaf/alloc.h>
+#include <aerospike/as_val_hashmap.h>
+#include <aerospike/as_val_hashmap_iterator.h>
+
+/* as_iterator fn hook table */
+#define __hook(t, n) .t = (typeof(iter_hooks.t)) n
+static const as_iterator_hooks iter_hooks = {
+	__hook(destroy,		as_val_hashmap_iterator_release),
+	__hook(has_next,	as_val_hashmap_iterator_has_next),
+	__hook(next,		as_val_hashmap_iterator_next)
+};
+
+static bool iter_next(as_val_hashmap_iterator *itr)
+{
+	if (itr->next)
+		return true;
+	if (itr->map->size == itr->count)
+		return false;
+
+	do {
+		itr->pos++;
+	} while (itr->map->st[itr->pos - 1] != ST_FULL);
+	itr->count++;
+	itr->next = true;
+	return true;
+}
+
+static void init_iter(as_val_hashmap_iterator *itr, as_val_hashmap *map)
+{
+	itr->map = map;
+	itr->next = false;
+	itr->pos = 0;
+	itr->count = 0;
+}
+
+/**
+ * Initialize hashmap iterator structure.
+ *
+ * @param itr	target iterator
+ * @param map	target map
+ * @return	upon success, @itr is returned, otherwise NULL
+ */
+as_val_hashmap_iterator *as_val_hashmap_iterator_init(
+	as_val_hashmap_iterator *itr, as_val_hashmap *map)
+{
+	if (!itr)
+		return NULL;
+	
+	init_iter(itr, map);
+	as_iterator_init((as_iterator *) itr, false, NULL, &iter_hooks);
+	return itr;
+}
+
+/**
+ * Allocate and initialize a new iterator structure
+ *
+ * @param map	target map
+ * @return	upon success, pointer to newly allocated iterator is returned,
+ *		otherwise, NULL.
+ */
+as_val_hashmap_iterator *as_val_hashmap_iterator_new(as_val_hashmap *map)
+{
+	as_val_hashmap_iterator *itr = cf_malloc(sizeof(as_val_hashmap_iterator));
+	if (!itr)
+		return NULL;
+	init_iter(itr, map);
+	as_iterator_init((as_iterator *) itr, true, NULL, &iter_hooks);
+	return itr;
+}
+
+/**
+ * Release iterator resources
+ *
+ * @param itr	target iterator
+ * @return	always returns true
+ */
+bool as_val_hashmap_iterator_release(as_val_hashmap_iterator *itr)
+{
+	itr->map = NULL;
+	return true;
+}
+
+/**
+ * Destroy iterator
+ *
+ * @param itr	target iterator
+ */
+void as_val_hashmap_iterator_destroy(as_val_hashmap_iterator *itr)
+{
+	as_iterator_destroy((as_iterator *) itr);
+}
+
+/**
+ * Determine if iterator has more values to traverse through
+ *
+ * @param itr	target iterator
+ * @return	true if iterator has more values, false otherwise
+ */
+bool as_val_hashmap_iterator_has_next(const as_val_hashmap_iterator *itr)
+{
+	return iter_next((as_val_hashmap_iterator *) itr);
+}
+
+/**
+ * Retrieve next value
+ *
+ * @param itr	target iterator
+ * @return	next value in map, or NULL
+ */
+const as_val *as_val_hashmap_iterator_next(as_val_hashmap_iterator *itr)
+{
+	size_t pos;
+	if (!iter_next(itr))
+		return NULL;
+	pos = itr->pos;
+	itr->next = false;
+	as_pair_init(&itr->pair, itr->map->key_tbl[pos-1],
+		     itr->map->val_tbl[pos-1]);
+	return (const as_val *) &itr->pair;
+}

--- a/src/main/aerospike/primes.c
+++ b/src/main/aerospike/primes.c
@@ -1,0 +1,41 @@
+#include "primes.h"
+
+static int is_prime(unsigned long x)
+{
+	unsigned long o = 4, i = 5;
+	do {
+		unsigned long q = x / i;
+		if (q < i)
+			return 1;
+		if (x == q * i)
+			return 0;
+		o ^= 6;
+		i += o;
+	} while (1);
+	return 1;
+}
+
+unsigned long next_prime(unsigned long n)
+{
+	unsigned long k, i, o;
+
+	switch (n) {
+	case 0:
+	case 1:
+	case 2:
+		return 2;
+	case 3:
+		return 3;
+	case 4:
+	case 5:
+		return 5;
+	}
+
+	k = n / 6;
+	i = n - 6 * k;
+	o = i < 2 ? 1 : 5;
+	n = 6 * k + o;
+	for (i = (3 + o) / 2; !is_prime(n); n += i)
+		i ^= 6;
+	return n;
+}

--- a/src/main/aerospike/primes.h
+++ b/src/main/aerospike/primes.h
@@ -1,0 +1,6 @@
+#ifndef __PRIMES_H_
+#define __PRIMES_H_ 1
+
+extern unsigned long next_prime(unsigned long n);
+
+#endif /* __PRIMES_H_ */

--- a/src/test/common.c
+++ b/src/test/common.c
@@ -11,6 +11,7 @@ PLAN( common ) {
     plan_add( types_bytes );
     plan_add( types_arraylist );
     plan_add( types_hashmap );
+    plan_add( types_val_hashmap );
     plan_add( types_nil );
     plan_add( types_vector );
 

--- a/src/test/types/types_val_hashmap.c
+++ b/src/test/types/types_val_hashmap.c
@@ -1,0 +1,296 @@
+#include "../test.h"
+
+#include <aerospike/as_string.h>
+#include <aerospike/as_integer.h>
+#include <aerospike/as_stringmap.h>
+#include <aerospike/as_map.h>
+#include <aerospike/as_msgpack.h>
+#include <aerospike/as_serializer.h>
+#include <aerospike/as_val_hashmap_iterator.h>
+#include <aerospike/as_val_hashmap.h>
+
+TEST(types_val_hashmap_empty, "as_val_hashmap is empty") {
+		as_val_hashmap *m = as_val_hashmap_new(.0f, .0f, 0);
+		assert_int_eq(as_map_size((as_map *) m), 0);
+		as_map_destroy((as_map *) m);
+}
+
+TEST(types_val_hashmap_ops, "as_val_hashmap ops") {
+	as_val *a = (as_val *) as_string_new_strdup("a");
+	as_val *b = (as_val *) as_string_new_strdup("b");
+	as_val *c = (as_val *) as_string_new_strdup("c");
+
+	as_integer *v= NULL;
+
+	as_val_hashmap *m = as_val_hashmap_new(.0f, .0f, 10);
+	assert_int_eq(as_val_hashmap_size(m), 0);
+
+	as_val_hashmap_set(m, as_val_reserve(a), (as_val *) as_integer_new(1));
+	as_val_hashmap_set(m, as_val_reserve(b), (as_val *) as_integer_new(2));
+	as_val_hashmap_set(m, as_val_reserve(c), (as_val *) as_integer_new(3));
+
+	assert_int_eq(as_val_hashmap_size(m), 3);
+
+	/* check individual values */
+
+	v = (as_integer *) as_val_hashmap_get(m, a);
+	assert_int_eq(v->value, 1);
+
+	v = (as_integer *) as_val_hashmap_get(m, b);
+	assert_int_eq(v->value, 2);
+
+	v = (as_integer *) as_val_hashmap_get(m, c);
+	assert_int_eq(v->value, 3);
+
+	/* resetting the values */
+
+	as_val_hashmap_set(m, as_val_reserve(a), (as_val *) as_integer_new(4));
+	as_val_hashmap_set(m, as_val_reserve(b), (as_val *) as_integer_new(5));
+	as_val_hashmap_set(m, as_val_reserve(c), (as_val *) as_integer_new(6));
+
+	assert_int_eq(as_val_hashmap_size(m), 3);
+
+	/* check individual values */
+
+	v = (as_integer *) as_val_hashmap_get(m, a);
+	assert_int_eq(v->value, 4);
+
+	v = (as_integer *) as_val_hashmap_get(m, b);
+	assert_int_eq(v->value, 5);
+
+	v = (as_integer *) as_val_hashmap_get(m, c);
+	assert_int_eq(v->value, 6);
+
+	/* remove an entry */
+
+	as_val_hashmap_remove(m, a);
+	assert_int_eq(as_val_hashmap_size(m), 2);
+
+	v = (as_integer *) as_val_hashmap_get(m, a);
+	assert_null(v);
+
+	v = (as_integer *) as_val_hashmap_get(m, b);
+	assert_int_eq(v->value, 5);
+
+	v = (as_integer *) as_val_hashmap_get(m, c);
+	assert_int_eq(v->value, 6);
+
+	/* clear the map */
+	as_val_hashmap_clear(m);
+	assert_int_eq(as_val_hashmap_size(m), 0);
+	/* resetting the values */
+
+	as_val_hashmap_set(m, as_val_reserve(a), (as_val *) as_integer_new(7));
+	as_val_hashmap_set(m, as_val_reserve(b), (as_val *) as_integer_new(8));
+	as_val_hashmap_set(m, as_val_reserve(c), (as_val *) as_integer_new(9));
+
+	assert_int_eq(as_val_hashmap_size(m), 3);
+
+	v = (as_integer *) as_val_hashmap_get(m, a);
+	assert_int_eq(v->value, 7);
+
+	v = (as_integer *) as_val_hashmap_get(m, b);
+	assert_int_eq(v->value, 8);
+
+	v = (as_integer *) as_val_hashmap_get(m, c);
+	assert_int_eq(v->value, 9);
+
+	as_val_hashmap_destroy(m);
+
+	as_val_destroy(a);
+	as_val_destroy(b);
+	as_val_destroy(c);
+}
+
+TEST(types_val_hashmap_map_ops, "as_val_hashmap w/ as_map ops") {
+	as_val * a = (as_val *) as_string_new_strdup("a");
+	as_val * b = (as_val *) as_string_new_strdup("b");
+	as_val * c = (as_val *) as_string_new_strdup("c");
+
+	as_integer * v = NULL;
+
+	as_map * m = (as_map *) as_val_hashmap_new(.0f, .0f, 10);
+	
+	assert_int_eq( as_map_size(m), 0 );
+
+	// Setting the values
+
+	as_map_set(m, as_val_reserve(a), (as_val *) as_integer_new(1));
+	as_map_set(m, as_val_reserve(b), (as_val *) as_integer_new(2));
+	as_map_set(m, as_val_reserve(c), (as_val *) as_integer_new(3));
+
+	assert_int_eq( as_map_size(m), 3 );
+
+	// check individual values
+
+	v = (as_integer *) as_map_get(m, a);
+	assert_int_eq( v->value, 1 );
+
+	v = (as_integer *) as_map_get(m, b);
+	assert_int_eq( v->value, 2 );
+
+	v = (as_integer *) as_map_get(m, c);
+	assert_int_eq( v->value, 3 );
+
+	// Resetting the values
+	
+	as_map_set(m, as_val_reserve(a), (as_val *) as_integer_new(4));
+	as_map_set(m, as_val_reserve(b), (as_val *) as_integer_new(5));
+	as_map_set(m, as_val_reserve(c), (as_val *) as_integer_new(6));
+
+	assert_int_eq( as_map_size(m), 3 );
+
+	// check individual values
+
+	v = (as_integer *) as_map_get(m, a);
+	assert_int_eq( v->value, 4 );
+
+	v = (as_integer *) as_map_get(m, b);
+	assert_int_eq( v->value, 5 );
+
+	v = (as_integer *) as_map_get(m, c);
+	assert_int_eq( v->value, 6 );
+
+	// remove an entry
+
+	as_map_remove(m, a);
+
+	assert_int_eq( as_map_size(m), 2 );
+
+	v = (as_integer *) as_map_get(m, a);
+	assert_null( v );
+
+	v = (as_integer *) as_map_get(m, b);
+	assert_int_eq( v->value, 5 );
+
+	v = (as_integer *) as_map_get(m, c);
+	assert_int_eq( v->value, 6 );
+
+	// Clear the map
+
+	as_map_clear(m);
+	assert_int_eq( as_map_size(m), 0 );
+
+	// Resetting the values
+
+	as_map_set(m, as_val_reserve(a), (as_val *) as_integer_new(7));
+	as_map_set(m, as_val_reserve(b), (as_val *) as_integer_new(8));
+	as_map_set(m, as_val_reserve(c), (as_val *) as_integer_new(9));
+
+	assert_int_eq( as_map_size(m), 3 );
+
+	v = (as_integer *) as_map_get(m, a);
+	assert_int_eq( v->value, 7 );
+
+	v = (as_integer *) as_map_get(m, b);
+	assert_int_eq( v->value, 8 );
+
+	v = (as_integer *) as_map_get(m, c);
+	assert_int_eq( v->value, 9 );
+
+	as_map_destroy((as_map *) m);
+
+	as_val_destroy(a);
+	as_val_destroy(b);
+	as_val_destroy(c);
+}
+
+TEST(types_val_hashmap_iterator, "as_val_hashmap w/ as_iterator ops") {
+
+	as_val_hashmap * m = as_val_hashmap_new(.0f, .0f, 10);
+	assert_int_eq( as_map_size((as_map *) m), 0 );
+
+	as_val_hashmap_set(m, (as_val *) as_string_new_strdup("a"), (as_val *) as_integer_new(1));
+	as_val_hashmap_set(m, (as_val *) as_string_new_strdup("b"), (as_val *) as_integer_new(2));
+	as_val_hashmap_set(m, (as_val *) as_string_new_strdup("c"), (as_val *) as_integer_new(3));
+	assert_int_eq( as_map_size((as_map *) m), 3 );
+
+	as_iterator * i = (as_iterator *) as_val_hashmap_iterator_new(m);
+
+	int count = 0;
+	while ( as_iterator_has_next(i) ) {
+		as_pair * p = (as_pair *) as_iterator_next(i);
+		as_integer * a = (as_integer *) as_pair_2(p);
+		as_integer * e = (as_integer *) as_map_get((as_map *) m, as_pair_1(p));
+		assert( a->value == e->value );
+		count ++;
+	}
+
+	as_iterator_destroy(i);
+
+	assert_int_eq( as_val_hashmap_size(m), count );
+
+	as_val_hashmap_destroy(m);
+}
+
+bool types_val_hashmap_foreach_callback(const as_val * key, const as_val * val, void * udata)
+{
+	int * sum = (int *) udata;
+	as_integer * i = as_integer_fromval(val);
+	if ( i ) {
+		(*sum) = (*sum) + (int)as_integer_get(i);
+	}
+	return true;
+}
+
+TEST(types_val_hashmap_foreach, "as_val_hashmap_foreach") {
+
+	int sum = 0;
+
+	as_val_hashmap * m = as_val_hashmap_new(.0f, .0f, 10);
+	as_stringmap_set_int64((as_map *) m, "a", 1);
+	as_stringmap_set_int64((as_map *) m, "b", 2);
+	as_stringmap_set_int64((as_map *) m, "c", 3);
+
+	as_val_hashmap_foreach(m, types_val_hashmap_foreach_callback, &sum);
+
+	assert_int_eq( sum, 6 );
+
+	as_val_hashmap_destroy(m);
+}
+
+TEST(types_val_hashmap_msgpack, "as_val_hashmap msgpack") {
+
+	as_val_hashmap * m1 = as_val_hashmap_new(.0f, .0f, 10);
+	as_stringmap_set_int64((as_map *) m1, "a", 1);
+	as_stringmap_set_int64((as_map *) m1, "b", 2);
+	as_stringmap_set_int64((as_map *) m1, "c", 3);
+
+	assert_int_eq( as_val_hashmap_size(m1), 3 );
+	assert_int_eq( as_stringmap_get_int64((as_map *) m1, "a"), 1);
+	assert_int_eq( as_stringmap_get_int64((as_map *) m1, "b"), 2);
+	assert_int_eq( as_stringmap_get_int64((as_map *) m1, "c"), 3);
+	
+    as_serializer ser;
+    as_msgpack_init(&ser);
+
+    as_buffer b;
+    as_buffer_init(&b);
+
+    as_serializer_serialize(&ser, (as_val *) m1, &b);
+
+	as_val * v2 = NULL;
+    as_serializer_deserialize(&ser, &b, &v2);
+
+    assert_not_null( v2 );
+    assert_int_eq( as_val_type(v2), AS_MAP );
+
+    as_map * m2 = as_map_fromval(v2);
+	assert_int_eq( as_map_size(m2), as_val_hashmap_size(m1) );
+
+	assert_int_eq( as_stringmap_get_int64(m2, "a"), 1);
+	assert_int_eq( as_stringmap_get_int64(m2, "b"), 2);
+	assert_int_eq( as_stringmap_get_int64(m2, "c"), 3);
+	
+	as_map_destroy(m2);
+	as_val_hashmap_destroy(m1);
+}
+
+SUITE(types_val_hashmap, "as_val_hashmap") {
+	suite_add(types_val_hashmap_empty);
+	suite_add(types_val_hashmap_ops);
+	suite_add(types_val_hashmap_map_ops);
+	suite_add(types_val_hashmap_iterator);
+	suite_add(types_val_hashmap_foreach);
+	suite_add(types_val_hashmap_msgpack);
+}


### PR DESCRIPTION
I've introduced a new hash map implementation (as_val_hashmap), which should be a drop-in replacement for as_hashmap. This implementation should work on keys of any type (numeric, string, etc.). Using this impl would avoid the constraints outlined in issue #2 .
