### PR TITLE
Bug fix for POWERpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
+include project/settings.mk
 ###############################################################################
 ##  SETTINGS                                                                 ##
 ###############################################################################
-include project/settings.mk
 
 # Modules
 MODULES :=
@@ -11,8 +11,12 @@ O = 3
 
 # Make-local Compiler Flags
 CC_FLAGS = -std=gnu99 -g -Wall -fPIC -O$(O)
-CC_FLAGS += -fno-common -fno-strict-aliasing
-CC_FLAGS += -march=nocona -DMARCH_$(ARCH)
+CC_FLAGS += -fno-common -fno-strict-aliasing -finline-functions
+ifeq ($(ARCH),$(filter $(ARCH),ppc64 ppc64le))
+  CC_FLAGS += -DMARCH_$(ARCH)
+else
+  CC_FLAGS += -march=nocona -DMARCH_$(ARCH)
+endif
 CC_FLAGS += -D_FILE_OFFSET_BITS=64 -D_REENTRANT -D_GNU_SOURCE $(EXT_CFLAGS)
 
 PREPRO_SUFFIX = .cpp
@@ -24,11 +28,8 @@ endif
 
 ifeq ($(OS),Darwin)
 CC_FLAGS += -D_DARWIN_UNLIMITED_SELECT
-ifneq ($(wildcard /usr/local/opt/openssl/include),)
-  CC_FLAGS += -I/usr/local/opt/openssl/include
-endif
 else
-CC_FLAGS += -finline-functions -rdynamic
+CC_FLAGS += -rdynamic
 endif
 
 ifneq ($(CF), )
@@ -49,58 +50,71 @@ CC_FLAGS += -pg -fprofile-arcs -ftest-coverage -g2
 LD_FLAGS += -pg -fprofile-arcs -lgcov
 endif
 
+# Include Paths
+# INC_PATH +=
+
+# Library Paths
+# LIB_PATH +=
+
 ###############################################################################
 ##  OBJECTS                                                                  ##
 ###############################################################################
 
 AEROSPIKE-OBJECTS =
+AEROSPIKE-OBJECTS += as_module.o
+AEROSPIKE-OBJECTS += as_nil.o
+AEROSPIKE-OBJECTS += as_result.o
 AEROSPIKE-OBJECTS += as_aerospike.o
+AEROSPIKE-OBJECTS += as_logger.o
+AEROSPIKE-OBJECTS += as_memtracker.o
+AEROSPIKE-OBJECTS += as_buffer.o
+AEROSPIKE-OBJECTS += as_pair.o
+AEROSPIKE-OBJECTS += as_stream.o
+AEROSPIKE-OBJECTS += as_iterator.o
+AEROSPIKE-OBJECTS += as_stringmap.o
+AEROSPIKE-OBJECTS += as_timer.o
+
+AEROSPIKE-OBJECTS += internal.o
+
+# serializers
+AEROSPIKE-OBJECTS += as_serializer.o
+AEROSPIKE-OBJECTS += as_msgpack.o
+AEROSPIKE-OBJECTS += as_msgpack_serializer.o
+
+# types
+AEROSPIKE-OBJECTS += as_boolean.o
+AEROSPIKE-OBJECTS += as_bytes.o
+AEROSPIKE-OBJECTS += as_integer.o
+AEROSPIKE-OBJECTS += as_list.o
+AEROSPIKE-OBJECTS += as_map.o
+AEROSPIKE-OBJECTS += as_rec.o
+AEROSPIKE-OBJECTS += as_string.o
+AEROSPIKE-OBJECTS += as_val.o
+
+# arraylist
 AEROSPIKE-OBJECTS += as_arraylist.o
 AEROSPIKE-OBJECTS += as_arraylist_hooks.o
 AEROSPIKE-OBJECTS += as_arraylist_iterator.o
 AEROSPIKE-OBJECTS += as_arraylist_iterator_hooks.o
-AEROSPIKE-OBJECTS += as_boolean.o
-AEROSPIKE-OBJECTS += as_buffer.o
-AEROSPIKE-OBJECTS += as_buffer_pool.o
-AEROSPIKE-OBJECTS += as_bytes.o
-AEROSPIKE-OBJECTS += as_double.o
-AEROSPIKE-OBJECTS += as_geojson.o
+
+# hashmap
 AEROSPIKE-OBJECTS += as_hashmap.o
 AEROSPIKE-OBJECTS += as_hashmap_hooks.o
 AEROSPIKE-OBJECTS += as_hashmap_iterator.o
 AEROSPIKE-OBJECTS += as_hashmap_iterator_hooks.o
-AEROSPIKE-OBJECTS += as_integer.o
-AEROSPIKE-OBJECTS += as_iterator.o
-AEROSPIKE-OBJECTS += as_list.o
-AEROSPIKE-OBJECTS += as_log.o
-AEROSPIKE-OBJECTS += as_map.o
-AEROSPIKE-OBJECTS += as_memtracker.o
-AEROSPIKE-OBJECTS += as_module.o
-AEROSPIKE-OBJECTS += as_msgpack.o
-AEROSPIKE-OBJECTS += as_msgpack_serializer.o
-AEROSPIKE-OBJECTS += as_nil.o
-AEROSPIKE-OBJECTS += as_pair.o
-AEROSPIKE-OBJECTS += as_password.o
-AEROSPIKE-OBJECTS += as_queue.o
-AEROSPIKE-OBJECTS += as_random.o
-AEROSPIKE-OBJECTS += as_rec.o
-AEROSPIKE-OBJECTS += as_result.o
-AEROSPIKE-OBJECTS += as_serializer.o
-AEROSPIKE-OBJECTS += as_stream.o
-AEROSPIKE-OBJECTS += as_string.o
-AEROSPIKE-OBJECTS += as_string_builder.o
-AEROSPIKE-OBJECTS += as_thread_pool.o
-AEROSPIKE-OBJECTS += as_timer.o
-AEROSPIKE-OBJECTS += as_val.o
+
 AEROSPIKE-OBJECTS += as_vector.o
+AEROSPIKE-OBJECTS += as_password.o
 AEROSPIKE-OBJECTS += crypt_blowfish.o
 
 CITRUSLEAF-OBJECTS =
 CITRUSLEAF-OBJECTS += cf_alloc.o
 CITRUSLEAF-OBJECTS += cf_b64.o
+CITRUSLEAF-OBJECTS += cf_bits.o
 CITRUSLEAF-OBJECTS += cf_clock.o
 CITRUSLEAF-OBJECTS += cf_crypto.o
 CITRUSLEAF-OBJECTS += cf_digest.o
+CITRUSLEAF-OBJECTS += cf_hooks.o
 CITRUSLEAF-OBJECTS += cf_ll.o
 CITRUSLEAF-OBJECTS += cf_queue.o
 CITRUSLEAF-OBJECTS += cf_queue_priority.o
@@ -113,8 +127,7 @@ OBJECTS =
 OBJECTS += $(AEROSPIKE-OBJECTS:%=$(TARGET_OBJ)/common/aerospike/%) 
 OBJECTS += $(CITRUSLEAF-OBJECTS:%=$(TARGET_OBJ)/common/citrusleaf/%)
 
-HEADER-SRC = $(shell find $(SOURCE_INCL) -type f -name "*.h")
-HEADER-TRG = $(patsubst $(SOURCE_INCL)/%.h, $(TARGET_INCL)/%.h, $(HEADER-SRC))
+HOOKED-OBJECTS = $(CITRUSLEAF-OBJECTS:%=$(TARGET_OBJ)/common-hooked/citrusleaf/%)
 
 ###############################################################################
 ##  MAIN TARGETS                                                             ##
@@ -123,40 +136,72 @@ HEADER-TRG = $(patsubst $(SOURCE_INCL)/%.h, $(TARGET_INCL)/%.h, $(HEADER-SRC))
 .PHONY: all
 all: build prepare
 
-.PHONY: build 
-build: libaerospike-common
-
 .PHONY: prepare
-prepare: $(HEADER-TRG)
+prepare: $(TARGET_INCL)/citrusleaf/*.h $(TARGET_INCL)/aerospike/*.h
 
-.PHONY: clean
-clean:
-	@rm -rf $(TARGET)
+.PHONY: build 
+build: libaerospike-common libaerospike-common-hooked
+
+.PHONY: build-clean
+build-clean:
+	@rm -rf $(TARGET_BIN)
+	@rm -rf $(TARGET_LIB)
+	@rm -rf $(TARGET_OBJ)
 
 .PHONY: libaerospike-common libaerospike-common.a libaerospike-common.$(DYNAMIC_SUFFIX)
 libaerospike-common: libaerospike-common.a libaerospike-common.$(DYNAMIC_SUFFIX)
 libaerospike-common.a: $(TARGET_LIB)/libaerospike-common.a
 libaerospike-common.$(DYNAMIC_SUFFIX): $(TARGET_LIB)/libaerospike-common.$(DYNAMIC_SUFFIX)
 
+
+.PHONY: libaerospike-common-hooked libaerospike-common-hooked.a libaerospike-common-hooked.$(DYNAMIC_SUFFIX)
+libaerospike-common-hooked: libaerospike-common-hooked.a libaerospike-common-hooked.$(DYNAMIC_SUFFIX)
+libaerospike-common-hooked.a: $(TARGET_LIB)/libaerospike-common-hooked.a
+libaerospike-common-hooked.$(DYNAMIC_SUFFIX): $(TARGET_LIB)/libaerospike-common-hooked.$(DYNAMIC_SUFFIX)
+
 ###############################################################################
 ##  BUILD TARGETS                                                            ##
 ###############################################################################
 
-$(TARGET_OBJ)/common/aerospike/%.o: $(SOURCE_MAIN)/aerospike/%.c $(SOURCE_INCL)/aerospike/*.h
+# COMMON
+
+$(TARGET_OBJ)/common/aerospike/%.o: $(SOURCE_MAIN)/aerospike/%.c $(SOURCE_INCL)/aerospike/*.h | modules 
 	$(object)
 
-$(TARGET_OBJ)/common/citrusleaf/%.o: $(SOURCE_MAIN)/citrusleaf/%.c $(SOURCE_INCL)/citrusleaf/*.h
+$(TARGET_OBJ)/common/citrusleaf/%.o: $(SOURCE_MAIN)/citrusleaf/%.c $(SOURCE_INCL)/citrusleaf/*.h | modules 
 	$(object)
 
-$(TARGET_LIB)/libaerospike-common.$(DYNAMIC_SUFFIX): $(OBJECTS)
+$(TARGET_LIB)/libaerospike-common.$(DYNAMIC_SUFFIX): $(OBJECTS) | modules 
 	$(library)
 
-$(TARGET_LIB)/libaerospike-common.a: $(OBJECTS)
+$(TARGET_LIB)/libaerospike-common.a: $(OBJECTS) | modules 
 	$(archive)
 
-$(TARGET_INCL)/%.h: $(SOURCE_INCL)/%.h
-	@mkdir -p $(@D)
-	cp $< $@
+# HOOKED COMMON
+
+$(TARGET_OBJ)/common-hooked/citrusleaf/%.o: CC_FLAGS += -DEXTERNAL_LOCKS
+$(TARGET_OBJ)/common-hooked/citrusleaf/%.o: $(SOURCE_MAIN)/citrusleaf/%.c $(SOURCE_INCL)/citrusleaf/*.h | modules
+	$(object)
+
+$(TARGET_LIB)/libaerospike-common-hooked.$(DYNAMIC_SUFFIX): $(HOOKED-OBJECTS) | modules 
+	$(library)
+
+$(TARGET_LIB)/libaerospike-common-hooked.a: $(HOOKED-OBJECTS) | modules 
+	$(archive)
+
+# COMMON HEADERS
+
+$(TARGET_INCL)/citrusleaf: | $(TARGET_INCL)
+	mkdir $@
+
+$(TARGET_INCL)/citrusleaf/%.h: $(SOURCE_INCL)/citrusleaf/%.h | $(TARGET_INCL)/citrusleaf
+	cp -p $^ $(TARGET_INCL)/citrusleaf
+
+$(TARGET_INCL)/aerospike: | $(TARGET_INCL)
+	mkdir $@
+
+$(TARGET_INCL)/aerospike/%.h:: $(SOURCE_INCL)/aerospike/%.h | $(TARGET_INCL)/aerospike
+	cp -p $^ $(TARGET_INCL)/aerospike
 
 ###############################################################################
-include project/test.mk project/rules.mk
+include project/modules.mk project/test.mk project/rules.mk

--- a/src/include/citrusleaf/cf_arch.h
+++ b/src/include/citrusleaf/cf_arch.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2008-2016 Aerospike, Inc.
+ * Copyright 2008-2014 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.
@@ -24,12 +24,16 @@ extern "C" {
  * CONSTANTS
  ******************************************************************************/
 
-#if ! (defined(MARCH_i686) || defined(MARCH_x86_64))
-#if defined(__LP64__) || defined(_LP64)
-#define MARCH_x86_64 1
-#else
-#define MARCH_i686 1
+#if defined(__powerpc64__)
+  #define MARCH_PPC64 1
 #endif
+
+#if ! (defined(MARCH_i686) || defined(MARCH_x86_64) || defined(MARCH_PPC64))
+  #if defined(__LP64__) || defined(_LP64)
+    #define MARCH_x86_64 1
+  #else
+    #define MARCH_i686 1
+  #endif
 #endif
 
 /******************************************************************************/

--- a/src/include/citrusleaf/cf_atomic.h
+++ b/src/include/citrusleaf/cf_atomic.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2008-2016 Aerospike, Inc.
+ * Copyright 2008-2014 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.
@@ -23,6 +23,20 @@
  *
  * cf_atomicX_add
  * Atomic addition: add a value b into an atomic integer a, and return the result
+ *
+ * cf_atomicX_cas
+ * Compare-and-swap: test a value b against an atomic integer a; if they
+ * are equal, store the value x into a, and return the initial value of a.
+ * "Success" can be checked by comparing the returned value against b
+ * NB: this is a strong memory barrier
+ *
+ * cf_atomicX_fas
+ * Fetch-and-swap: swap the values of  b and a 
+ * 
+ * cf_atomicX_addunless
+ * Increment-unless: test a value b against an atomic integer a.  If they
+ * are NOT equal, add x to a, and return non-zero; if they ARE equal, return
+ * zero 
  **/
 
 #include <stdint.h>
@@ -37,12 +51,6 @@
 extern "C" {
 #endif
 
-// Concurrency kit needs to be under extern "C" when compiling C++.
-#include <aerospike/ck/ck_pr.h>
-
-/******************************************************************************
- * TYPES
- *****************************************************************************/
 
 #ifdef MARCH_i686
 #define SIZEOF_ATOMIC_INT 4
@@ -61,6 +69,17 @@ typedef volatile uint64_t cf_atomic_int;
 typedef uint64_t cf_atomic_int_t; // the point here is a type of the same size as cf_atomic_int but isn't atomic
 #endif
 
+#ifdef MARCH_PPC64
+#define SIZEOF_ATOMIC_INT 8
+typedef volatile uint64_t cf_atomic64;
+typedef volatile uint32_t cf_atomic32;
+typedef volatile uint64_t cf_atomic_p;
+typedef volatile uint64_t cf_atomic_int;
+typedef uint64_t cf_atomic_int_t; // the point here is a type of the same size as cf_atomic_int but isn't atomic
+#endif
+
+
+
 /******************************************************************************
  * MACROS
  *****************************************************************************/
@@ -70,6 +89,7 @@ typedef uint64_t cf_atomic_int_t; // the point here is a type of the same size a
 #define cf_atomic32_sub(a,b) (cf_atomic32_add((a), (0 - (b))))
 #define cf_atomic32_incr(a) (cf_atomic32_add((a), 1))
 #define cf_atomic32_decr(a) (cf_atomic32_add((a), -1))
+
 
 #ifdef MARCH_x86_64
 
@@ -113,12 +133,34 @@ typedef uint64_t cf_atomic_int_t; // the point here is a type of the same size a
 #ifndef CF_WINDOWS
 #ifdef MARCH_x86_64
 
+#define cf_atomic_p_cas(_a, _b, _x) cf_atomic64_cas(_a, _b, _x)
+#define cf_atomic_p_cas_m(_a, _b, _x) cf_atomic64_cas_m(_a, _b, _x)
+#define cf_atomic_p_fas(_a, _b) cf_atomic64_fas(_a, _b)
+#define cf_atomic_p_fas_m(_a, _b) cf_atomic64_fas_m(_a, _b)
+#define cf_atomic_p_addunless(_a, _b, _x) cf_atomic64_addunless(_a, _b, _x)
+#define cf_atomic_p_setmax(_a, _x) cf_atomic64_setmax(_a, _x)
+
+#define cf_atomic_int_cas(_a, _b, _x) cf_atomic64_cas(_a, _b, _x)
+#define cf_atomic_int_cas_m(_a, _b, _x) cf_atomic64_cas_m(_a, _b, _x)
+#define cf_atomic_int_fas(_a, _b) cf_atomic64_fas(_a, _b)
+#define cf_atomic_int_fas_m(_a, _b) cf_atomic64_fas_m(_a, _b)
+#define cf_atomic_int_addunless(_a, _b, _x) cf_atomic64_addunless(_a, _b, _x)
 #define cf_atomic_int_setmax(_a, _x) cf_atomic64_setmax(_a, _x)
 
 #else // ifndef CF_WINDOWS && ifndef MARCH_x86_64
 
+#define cf_atomic_p_cas(_a, _b, _x) cf_atomic32_cas(_a, _b, _x)
+#define cf_atomic_p_cas_m(_a, _b, _x) cf_atomic32_cas_m(_a, _b, _x)
+#define cf_atomic_p_fas(_a, _b) cf_atomic32_fas(_a, _b)
+#define cf_atomic_p_fas_m(_a, _b) cf_atomic32_fas_m(_a, _b)
+#define cf_atomic_p_addunless(_a, _b, _x) cf_atomic32_addunless(_a, _b, _x)
 #define cf_atomic_p_setmax(_a, _x) cf_atomic32_setmax(_a, _x)
 
+#define cf_atomic_int_cas(_a, _b, _x) cf_atomic32_cas(_a, _b, _x)
+#define cf_atomic_int_cas_m(_a, _b, _x) cf_atomic32_cas_m(_a, _b, _x)
+#define cf_atomic_int_fas(_a, _b) cf_atomic32_fas(_a, _b)
+#define cf_atomic_int_fas_m(_a, _b) cf_atomic32_fas_m(_a, _b)
+#define cf_atomic_int_addunless(_a, _b, _x) cf_atomic32_addunless(_a, _b, _x)
 #define cf_atomic_int_setmax(_a, _x) cf_atomic32_setmax(_a, _x)
 
 #endif // ifdef MARCH_x86_64
@@ -131,8 +173,27 @@ typedef uint64_t cf_atomic_int_t; // the point here is a type of the same size a
 
 #else // ifndef CF_WINDOWS
 
-#define smb_mb() ck_pr_fence_memory()
-//#define smb_mb() asm volatile("mfence":::"memory")
+#ifdef MARCH_PPC64
+
+#define smb_mb() asm volatile("lwsync":::"memory")
+
+#else
+
+#define smb_mb() asm volatile("mfence":::"memory")
+
+#endif
+
+/* CF_BARRIER
+ * All preceding memory accesses must commit before any following accesses */
+#define CF_MEMORY_BARRIER() __asm__ __volatile__ ("lock; addl $0,0(%%esp)" : : : "memory")
+
+/* CF_BARRIER_READ
+ * All preceding memory accesses must commit before any following accesses */
+#define CF_MEMORY_BARRIER_READ() CF_MEMORY_BARRIER()
+
+/* CF_BARRIER_WRITE
+ * All preceding memory accesses must commit before any following accesses */
+#define CF_MEMORY_BARRIER_WRITE() __asm__ __volatile__ ("" : : : "memory")
 
 #endif // CF_WINDOWS
 
@@ -167,29 +228,80 @@ static inline int64_t cf_atomic64_add(cf_atomic64 *a, int64_t b) {
 #ifdef MARCH_x86_64
 
 static inline int64_t cf_atomic64_add(cf_atomic64 *a, int64_t b) {
-	return ck_pr_faa_64((uint64_t*)a, b) + b;
-	//int64_t i = b;
-	//__asm__ __volatile__ ("lock; xaddq %0, %1" : "+r" (b), "+m" (*a) : : "memory");
-	//return(b + i);
+	int64_t i = b;
+	__asm__ __volatile__ ("lock; xaddq %0, %1" : "+r" (b), "+m" (*a) : : "memory");
+	return(b + i);
 }
 
-static inline int64_t cf_atomic64_setmax(cf_atomic64 *a, int64_t x) {
-	uint64_t prior;
-	int64_t cur;
+#define cf_atomic64_cas_m(_a, _b, _x) ({ \
+	__typeof__(_b) __b = _b; \
+	__asm__ __volatile__ ("lock; cmpxchgq %1,%2" : "=a"(__b) : "q"(_x), "m"(*(_a)), "0"(_b) : "memory"); \
+	__b; \
+})
+
+#define cf_atomic64_fas_m(_a, _b) ({ \
+	__typeof__(_b) __b; \
+	__asm__ __volatile__ ("lock; xchgq %0,%1" : "=r"(__b) : "m"(*(_a)), "0"(_b)); \
+	__b; \
+})
+
+static inline int64_t cf_atomic64_cas(cf_atomic64 *a, int64_t b, int64_t x) {
+	int64_t p;
+	__asm__ __volatile__ ("lock; cmpxchgq %1,%2" : "=a"(p) : "q"(x), "m"(*(a)), "0"(b) : "memory");
+	return(p);
+}
+
+
+static inline int64_t cf_atomic64_fas(cf_atomic64 *a, cf_atomic64 *b) {
+	int64_t p;
+	__asm__ __volatile__ ("lock; xchgq %0,%1" : "=r"(p) : "m"(*(a)), "0"(*(b)) : "memory");
+	return(p);
+}
+
+static inline int64_t cf_atomic64_addunless(cf_atomic64 *a, int64_t b, int64_t x) {
+	int64_t prior, cur;
 
 	// Get the current value of the atomic integer
 	cur = cf_atomic64_get(*a);
 
 	for ( ;; ) {
 		// Check if the current value is equal to the criterion
+		if (cur == b)
+			break;
+
+		// Attempt a compare-and-swap, which will return the value of cur
+		// prior to the operation
+		prior = cf_atomic64_cas(a, cur, cur + x);
+
+		// If prior and cur are equal, then the operation has succeeded;
+		// otherwise, set cur to prior and go around again
+		if (prior == cur)
+			break;
+		cur = prior;
+	}
+
+	return(cur != b);
+}
+
+static inline int64_t cf_atomic64_setmax(cf_atomic64 *a, int64_t x) {
+	int64_t prior, cur;
+
+	/* Get the current value of the atomic integer */
+	cur = cf_atomic64_get(*a);
+
+	for ( ;; ) {
+		/* Check if the current value is equal to the criterion */
 		if (cur >= x)
 			break;
 
-		// Attempt compare-and-swap
-		if (ck_pr_cas_64_value((uint64_t*)a, cur, x, &prior))
-			break;
+		/* Attempt a compare-and-swap, which will return the value of cur
+		 * prior to the operation */
+		prior = cf_atomic64_cas(a, cur, x);
 
-		// Operation failed, set cur to prior and go around again
+		/* If prior and cur are equal, then the operation has succeeded;
+		 * otherwise, set cur to prior and go around again */
+		if (prior == cur)
+			break;
 		cur = prior;
 	}
 
@@ -220,29 +332,80 @@ static inline int32_t cf_atomic32_add(cf_atomic32 *a, int32_t b){
 #ifndef CF_WINDOWS
 
 static inline int32_t cf_atomic32_add(cf_atomic32 *a, int32_t b){
-	return ck_pr_faa_32((uint32_t*)a, b) + b;
-	//int32_t i = b;
-	//__asm__ __volatile__ ("lock; xadd %0, %1" : "+r" (b), "+m" (*a) : : "memory");
-	//return(b + i);
+	int32_t i = b;
+#ifdef MARCH_PPC64
+        __atomic_fetch_add(a, b, __ATOMIC_ACQUIRE);
+#else
+        __asm__ __volatile__ ("lock; xadd %0, %1" : "+r" (b), "+m" (*a) : : "memory");
+#endif
+	return(b + i);
+}
+
+#define cf_atomic32_fas_m(_a, _b) ({ \
+	__typeof__(_b) __b; \
+	__asm__ __volatile__ ("lock; xchg %0,%1" : "=r"(__b) : "m"(*(_a)), "0"(_b)); \
+	__b; \
+})
+
+#define cf_atomic32_cas_m(_a, _b, _x) \ ({ \
+	__typeof__(_b) __b = _b; \
+	__asm__ __volatile__ ("lock; cmpxchg %1,%2" : "=a"(__b) : "q"(_x), "m"(*(_a)), "0"(_b) : "memory"); \
+	__b; \
+})
+
+static inline int32_t cf_atomic32_cas(cf_atomic32 *a, int32_t b, int32_t x) {
+	int32_t p;
+	__asm__ __volatile__ ("lock; cmpxchg %1,%2" : "=a"(p) : "q"(x), "m"(*(a)), "0"(b) : "memory");
+	return(p);
+}
+
+static inline int32_t cf_atomic32_fas(cf_atomic32 *a, cf_atomic32 *b) {
+	int32_t p;
+	__asm__ __volatile__ ("lock; xchg %0,%1" : "=r"(p) : "m"(*(a)), "0"(*(b)) : "memory");
+	return(p);
+}
+
+static inline int32_t cf_atomic32_addunless(cf_atomic32 *a, int32_t b, int32_t x) {
+	int32_t prior, cur;
+	
+	// Get the current value of the atomic integer
+	cur = cf_atomic32_get(*a);
+
+	for ( ;; ) {
+		// Check if the current value is equal to the criterion 
+		if (cur == b) break;
+		
+		// Attempt a compare-and-swap, which will return the value of cur
+		// prior to the operation 
+		prior = cf_atomic32_cas(a, cur, cur + x);
+		
+		// If prior and cur are equal, then the operation has succeeded;
+		// otherwise, set cur to prior and go around again
+		if (prior == cur) break;
+
+		cur = prior;
+	}
+	return(cur != b);
 }
 
 static inline int32_t cf_atomic32_setmax(cf_atomic32 *a, int32_t x) {
-	uint32_t prior;
-	int32_t cur;
+	int32_t prior, cur;
 
 	// Get the current value of the atomic integer
 	cur = cf_atomic32_get(*a);
 
 	for ( ;; ) {
 		// Check if the current value is equal to the criterion
-		if (cur >= x)
-			break;
+		if (cur >= x) break;
 
-		// Attempt compare-and-swap
-		if (ck_pr_cas_32_value((uint32_t*)a, cur, x, &prior))
-			break;
+		// Attempt a compare-and-swap, which will return the value of cur
+		// prior to the operation
+		prior = cf_atomic32_cas(a, cur, x);
 
-		// Operation failed, set cur to prior and go around again
+		// If prior and cur are equal, then the operation has succeeded;
+		// otherwise, set cur to prior and go around again
+		if (prior == cur) break;
+
 		cur = prior;
 	}
 


### PR DESCRIPTION
Compile on POWER was failing because the header files had x86 assembly code built in, and compiler flags that were not compatible with POWER.  I added #ifs to Makefile, cf_atomic.h, and cf_arch.h to check the architecture and perform accordingly
