### PR TITLE
Replace the yield with an isb on Arm.

### DIFF
--- a/src/include/aerospike/as_arch.h
+++ b/src/include/aerospike/as_arch.h
@@ -32,7 +32,7 @@
 
 #elif defined __aarch64__
 
-#define as_arch_pause() asm volatile("yield" : : : "memory")
+#define as_arch_pause() asm volatile("isb" : : : "memory")
 
 #endif
 


### PR DESCRIPTION
The yield instruction is treated as a nop on Arm processors which is very different than the x86 pause instruction that stalls execution for ~40 cycles.

An ISB serializes the pipeline and has been shown to be roughly analogous to the pause delays and is used is other databases for spinloops and adaptive spin loops where not hammering the cache line is important.